### PR TITLE
Build OpenSSL as a shared library when `BUILD_SHARED_LIBS` is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ if(NUMBER_OF_THREADS GREATER 1)
     endif()
 endif()
 
-if(OPENSSL_USE_STATIC_LIBS)
+if(NOT BUILD_SHARED_LIBS)
     list(APPEND OPENSSL_CONFIGURE_OPTIONS no-shared)
 endif()
 
@@ -219,6 +219,20 @@ if(MSVC AND DEFINED OPENSSL_MSVC_STATIC_RT)
     elseif(NOT OPENSSL_MSVC_STATIC_RT AND NOT OPENSSL_BUILD_SHARED_LIBS)
         message(WARNING "OPENSSL_MSVC_STATIC_RT is OFF, but OpenSSL will be built with /MT")
     endif()
+endif()
+
+if(DEFINED OPENSSL_USE_STATIC_LIBS)
+    if(OPENSSL_USE_STATIC_LIBS AND OPENSSL_BUILD_SHARED_LIBS)
+        message(WARNING "OPENSSL_USE_STATIC_LIBS is ON, but OpenSSL will be built as a shared library")
+    elseif(NOT OPENSSL_USE_STATIC_LIBS AND NOT OPENSSL_BUILD_SHARED_LIBS)
+        message(WARNING "OPENSSL_USE_STATIC_LIBS is OFF, but OpenSSL will be built as a static library")
+    endif()
+endif()
+
+if(BUILD_SHARED_LIBS AND NOT OPENSSL_BUILD_SHARED_LIBS)
+    message(WARNING "BUILD_SHARED_LIBS is ON, but OpenSSL will be built as a static library")
+elseif(NOT BUILD_SHARED_LIBS AND OPENSSL_BUILD_SHARED_LIBS)
+    message(WARNING "BUILD_SHARED_LIBS is OFF, but OpenSSL will be built as a shared library")
 endif()
 
 # Parse Makefile

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ choco install -y cmake jom strawberryperl nasm ccache --installargs 'ADD_CMAKE_T
 ### Notes
 
 - `OPENSSL_CONFIGURE_OPTIONS`
-  - `no-shared` is added when `OPENSSL_USE_STATIC_LIBS` is `ON`
+  - `no-shared` is added when `BUILD_SHARED_LIBS` is `OFF`
   - `no-tests` is added when `OPENSSL_TEST` is `OFF`
 - `OPENSSL_ENABLE_PARALLEL`
   - Detect the number of processors using `ProcessorCount` module


### PR DESCRIPTION
Replace the role of `OPENSSL_USE_STATIC_LIBS` with `BUILD_SHARED_LIBS`.