### PR TITLE
Relax target platform detection

### DIFF
--- a/cmake/ConfigureOpenSSL.cmake
+++ b/cmake/ConfigureOpenSSL.cmake
@@ -118,19 +118,6 @@ function(configure_openssl)
         file(MAKE_DIRECTORY ${CONFIGURE_BUILD_DIR})
     endif()
 
-    execute_process(
-        COMMAND ${CONFIGURE_TOOL} ${CONFIGURE_FILE} LIST
-        WORKING_DIRECTORY ${CONFIGURE_BUILD_DIR}
-        OUTPUT_VARIABLE PLATFORM_LIST
-        COMMAND_ERROR_IS_FATAL ANY
-    )
-    string(REPLACE "\n" ";" PLATFORM_LIST ${PLATFORM_LIST})
-    list(GET CONFIGURE_OPTIONS 0 TARGET_PLATFORM)
-
-    if(NOT TARGET_PLATFORM IN_LIST PLATFORM_LIST)
-        message(FATAL_ERROR "${TARGET_PLATFORM} isn't supported")
-    endif()
-
     message(STATUS "Configure OpenSSL")
     list(APPEND CONFIGURE_COMMAND ${CONFIGURE_TOOL} ${CONFIGURE_FILE} ${CONFIGURE_OPTIONS})
 

--- a/cmake/DetectTargetPlatform.cmake
+++ b/cmake/DetectTargetPlatform.cmake
@@ -62,7 +62,7 @@ function(detect_target_platform TARGET)
     endif()
 
     if(${TARGET} STREQUAL "")
-        message(FATAL_ERROR "Failed to detect OpenSSL target platform")
+        message(WARNING "Failed to detect the target platform for OpenSSL")
     endif()
 
     return(PROPAGATE ${TARGET})

--- a/cmake/FindVcvarsall.cmake
+++ b/cmake/FindVcvarsall.cmake
@@ -28,6 +28,8 @@ function(find_vcvarsall)
 endfunction()
 
 function(set_vcvarsall_command COMMAND)
+    set(${COMMAND} "")
+
     if(MSVC)
         find_vcvarsall()
 
@@ -63,13 +65,9 @@ function(set_vcvarsall_command COMMAND)
             endif()
         endif()
 
-        if(NOT DEFINED VCVARSALL_ARCH)
-            message(FATAL_ERROR "Couldn't select appropriate vcvarsall.bat argument")
+        if(DEFINED VCVARSALL_ARCH)
+            set(${COMMAND} ${VCVARSALL} ${VCVARSALL_ARCH} &&)
         endif()
-
-        set(${COMMAND} ${VCVARSALL} ${VCVARSALL_ARCH} &&)
-    else()
-        set(${COMMAND} "")
     endif()
 
     return(PROPAGATE ${COMMAND})


### PR DESCRIPTION
Configuration could succeed without defining `OPENSSL_TARGET_PLATFORM` on some platforms.