### PR TITLE
Use relative path for ccache

### DIFF
--- a/cmake/ConfigureOpenSSL.cmake
+++ b/cmake/ConfigureOpenSSL.cmake
@@ -77,7 +77,7 @@ function(apply_ccache FILE)
         endif()
 
         file(READ ${FILE} MAKEFILE)
-        string(REPLACE "\nCC=" "\nCC=${CCACHE} " MAKEFILE "${MAKEFILE}")
+        string(REPLACE "\nCC=" "\nCC=ccache " MAKEFILE "${MAKEFILE}")
 
         if(MSVC)
             string(REPLACE "/Zi /Fdossl_static.pdb " "" MAKEFILE "${MAKEFILE}")


### PR DESCRIPTION
`nmake` does not work with long absolute `ccache` paths.

Fix #23