### PR TITLE
Fix paths with spaces

### DIFF
--- a/cmake/ConfigureOpenSSL.cmake
+++ b/cmake/ConfigureOpenSSL.cmake
@@ -77,7 +77,7 @@ function(apply_ccache FILE)
         endif()
 
         file(READ ${FILE} MAKEFILE)
-        string(REPLACE "\nCC=" "\nCC=ccache " MAKEFILE "${MAKEFILE}")
+        string(REGEX REPLACE "(\nCC=)([^\n]*)" "\\1\"${CCACHE}\" \"\\2\"" MAKEFILE "${MAKEFILE}")
 
         if(MSVC)
             string(REPLACE "/Zi /Fdossl_static.pdb " "" MAKEFILE "${MAKEFILE}")


### PR DESCRIPTION
fix `msvc`,`gcc`,`ccache` paths with spaces
issus: https://github.com/jimmy-park/openssl-cmake/issues/23