### PR TITLE
Fix missing quotes around paths in execution of install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,17 +347,16 @@ endif()
 
 # Install OpenSSL
 if(OPENSSL_INSTALL)
-    set(OPENSSL_INSTALL_COMMAND ${OPENSSL_BUILD_TOOL} ${OPENSSL_INSTALL_TARGET})
+    set(OPENSSL_INSTALL_COMMAND "\"${OPENSSL_BUILD_TOOL}\" ${OPENSSL_INSTALL_TARGET}")
 
     if(MSVC)
-        list(APPEND OPENSSL_INSTALL_COMMAND /NOLOGO)
+        set(OPENSSL_INSTALL_COMMAND "${OPENSSL_INSTALL_COMMAND} /NOLOGO")
     endif()
 
     install(CODE
         "execute_process(
             COMMAND ${OPENSSL_INSTALL_COMMAND}
-            WORKING_DIRECTORY ${openssl_BINARY_DIR}
-            OUTPUT_QUIET
+            WORKING_DIRECTORY \"${openssl_BINARY_DIR}\"
         )"
     )
 endif()


### PR DESCRIPTION
Proposed change to remove the `OUTPUT_QUIET` flag, as install currently fails completely silently due to this flag. I think it would be beneficial to show some output to aid troubleshooting (as is the case now).

The issue itself is due to the command arguments are stored in a list, and when `OPENSSL_BUILD_TOOL` is on a path that contains whitespaces, all whitespace is removed when its actually executed, thus the path no longer being valid.
Another problem at the same place arises but this is only in form of a warning from cmake, is that `OPENSSL_INSTALL_COMMAND` is a list, and when passed as the `COMMAND` argument to `execute_process`, semicolons are inserted between each element, and the command is executed like that.